### PR TITLE
fix drop down widget bug

### DIFF
--- a/widgets/Dropdown.php
+++ b/widgets/Dropdown.php
@@ -82,7 +82,7 @@ class Dropdown extends \yii\bootstrap\Dropdown
      * @return string the rendering result.
      * @throws InvalidConfigException if the label option is not specified in one of the items.
      */
-    protected function renderItems($items)
+    protected function renderItems($items, $options = [])
     {
         $lines = [];
         if ($this->title) {


### PR DESCRIPTION
 PHP Warning – yii\base\ErrorException
Declaration of icron\metronic\widgets\Dropdown::renderItems($items) should be compatible with yii\bootstrap\Dropdown::renderItems($items, $options = Array)